### PR TITLE
Removed eventual C comment in command in create_dict_of_defines

### DIFF
--- a/create_f77_zmq_h_py2.py
+++ b/create_f77_zmq_h_py2.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python2
 #
 #    f77_zmq : Fortran 77 bindings for the ZeroMQ library
-#    Copyright (C) 2014 Anthony Scemama 
-#    
+#    Copyright (C) 2014 Anthony Scemama
+#
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -25,7 +25,7 @@
 # 31062 Toulouse Cedex 09, France
 
 
-
+import re
 import sys
 import ctypes
 
@@ -47,6 +47,7 @@ def create_dict_of_defines(lines,file_out):
       if key[0] == '_' or '(' in key or ',' in value:
         continue
       command = "%(key)s=%(value)s\nd['%(key)s']=%(key)s"%locals()
+      command = re.sub("/\*.*?\*/", "", command)
       exec command in locals()
 
   # Add the version number:
@@ -70,9 +71,9 @@ def create_prototypes(lines,file_out):
   typ_conv = {
       'long'   : 'integer*8' ,
       'int'    : 'integer' ,
-      'float'  : 'real', 
-      'char*'  : 'character*(64)', 
-      'double' : 'double precision', 
+      'float'  : 'real',
+      'char*'  : 'character*(64)',
+      'double' : 'double precision',
       'void*'  : 'integer*%d'%(ctypes.sizeof(ctypes.c_voidp)),
       'void'   : None
       }

--- a/create_f77_zmq_h_py3.py
+++ b/create_f77_zmq_h_py3.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 #
 #    f77_zmq : Fortran 77 bindings for the ZeroMQ library
-#    Copyright (C) 2014 Anthony Scemama 
-#    
+#    Copyright (C) 2014 Anthony Scemama
+#
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -25,7 +25,7 @@
 # 31062 Toulouse Cedex 09, France
 
 
-
+import re
 import sys
 import ctypes
 
@@ -48,6 +48,7 @@ def create_dict_of_defines(lines,file_out):
         continue
       d[key] = value
       command = "%(key)s=%(value)s\nd['%(key)s']=%(key)s"%locals()
+      command = re.sub("/\*.*?\*/", "", command)
       exec(command, locals())
 
   # Add the version number:
@@ -71,9 +72,9 @@ def create_prototypes(lines,file_out):
   typ_conv = {
       'long'   : 'integer*8' ,
       'int'    : 'integer' ,
-      'float'  : 'real', 
-      'char*'  : 'character*(64)', 
-      'double' : 'double precision', 
+      'float'  : 'real',
+      'char*'  : 'character*(64)',
+      'double' : 'double precision',
       'void*'  : 'integer*%d'%(ctypes.sizeof(ctypes.c_voidp)),
       'void'   : None
       }


### PR DESCRIPTION
I created this PR since I had the case where the input header file had C comments `/*......*/` on the define lines