### PR TITLE
Handle empty #define (?)

### DIFF
--- a/create_f77_zmq_h_py2.py
+++ b/create_f77_zmq_h_py2.py
@@ -44,7 +44,7 @@ def create_dict_of_defines(lines,file_out):
       buffer = line.split()
       key = buffer[1]
       value = " ".join(buffer[2:])
-      if key[0] == '_' or '(' in key or ',' in value:
+      if key[0] == '_' or not value or '(' in key or ',' in value or not value:
         continue
       command = "%(key)s=%(value)s\nd['%(key)s']=%(key)s"%locals()
       command = re.sub("/\*.*?\*/", "", command)


### PR DESCRIPTION
Fix:
```
Traceback (most recent call last):
  File "create_f77_zmq_h.py", line 34, in <module>
    x.main()
  File "/home/travis/build/LCPQ/quantum_package/install/_build/f77zmq/create_f77_zmq_h_py2.py", line 119, in main
    create_dict_of_defines(lines,file_out)
  File "/home/travis/build/LCPQ/quantum_package/install/_build/f77zmq/create_f77_zmq_h_py2.py", line 51, in create_dict_of_defines
    exec command in locals()
  File "<string>", line 1
    ZMQ_EXPORT=
```
but not defining a variable is the value is empty. 

Note that it's maybe better to declare it at empty (\"\") value. 